### PR TITLE
Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,20 +76,33 @@ By default, MACs are checked randomly. If you want to screen a specific range, u
 | **`-F`**, `--from` | Set first MAC to check (`--range` is forced) |
 |  **`-L`**, `--to`  | Set last MAC to check (`--range` is forced)  |
 
+
+🆕 You can now tell `mcbash` to use your proxy (credentials supported too).
+
+|       Option              | Functionality                                           |
+|:-------------------------:|---------------------------------------------------------|
+| **`-P`**, `--proxy`       | Set the proxy URL (any authentication method supported  |
+| **`-pu`**, `--proxy-user` | Set your proxy credentials `user:password`              |
+
 #### Change default parameters
 
 The config file (`mcbash.conf`) is created during the install process here : `$HOME/.mcbash/mcbash.conf`. Change some values according to your needs.
 
 ### Use examples
 
-The program sleeps 1.5 seconds between each requests, pauses every 10 requests for 3 seconds, stops after 1500 MACs checkeds, and consider timeout after 2 seconds (timeouts trigger a pause to avoid flood) :
-
 - `mcbash my-fakedns.org:8080 -w 1.5 -b 10 -d 3 -s 1500 -t 2`
 
-Scan from first (`-F`) to last (`-L`) provided MAC :
+The program sleeps 1.5 seconds between each requests, pauses every 10 requests for 3 seconds, stops after 1500 MACs checkeds, and consider timeout after 2 seconds (timeouts trigger a pause to avoid flood).
+
 
 - `mcbash my-fakedns.org:8080 -F 00:1A:79:00:00:00 -L 00:1A:79:00:11:11`
 
+Scan from first (`-F`) to last (`-L`) provided MAC.
+
+
+- `mcbash my-fakedns.org:8080 --proxy http://localhost:12345 --proxy-user user:password`
+
+Tells `mcbash` to communicate through proxy `http://localhost:12345` with `user:password` username and password.
 
 ## Instructions for the careless mind
 

--- a/bin/mcbash
+++ b/bin/mcbash
@@ -1,9 +1,6 @@
 #!/bin/bash
 #
 
-# TODO :
-# 1) add option to select MAC format (--format); e.g. AA:BB:CC:xx:xx:xx
-
 _RED=$(tput setaf 1)
 _GREEN=$(tput setaf 2)
 _YELLOW=$(tput setaf 3)
@@ -44,9 +41,9 @@ for (( i=0;i<$ELEMENTS;i++)); do
 		$(echo ${args[${i}]}) == "--url" ]] && \
 		argument_dns=$(( i + 1 )) && \
 		dns=${args[${argument_dns}]}
-	[[ $(echo ${args[${i}]} | grep -o "\.[a-z][a-z]" ) || \
-		$(echo ${args[${i}]} | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" ) ]] && \
-		dns=${args[${i}]}
+	#[[ $(echo ${args[${i}]} | grep -o "\.[a-z][a-z]" ) || \
+	#	$(echo ${args[${i}]} | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" ) ]] && \
+	#	dns=${args[${i}]}
 	[[ $(echo ${args[${i}]}) == "-w" || \
 		$(echo ${args[${i}]}) == "--wait" ]] && \
 		argument_request_delay=$(( i + 1 )) && \
@@ -83,6 +80,16 @@ for (( i=0;i<$ELEMENTS;i++)); do
 		range=True && \
 		argument_range_to=$(( i + 1 )) && \
 		range_to=${args[${argument_range_to}]}
+	[[ $(echo ${args[${i}]}) == "-P" ||
+		$(echo ${args[${i}]}) == "--proxy" ]] && \
+		argument_proxy_url=$(( i + 1 )) && \
+		proxy_url=${args[${argument_proxy_url}]} && \
+		proxy_url_option=$(echo "-x $proxy_url")
+	[[ $(echo ${args[${i}]}) == "-pu" ||
+		$(echo ${args[${i}]}) == "--proxy-user" ]] && \
+		argument_proxy_user=$(( i + 1 )) && \
+		proxy_user=${args[${argument_proxy_user}]} && \
+		proxy_user_option=$(echo "--proxy-anyauth --proxy-user $proxy_user")
 	[[ $(echo ${args[${i}]}) == "-h" || $(echo ${args[${i}]}) == "--help" ]] && \
 		echo -e "${_BOLD}Help menu :${_RESET} \
 		\n -b ${_BLUE}X${_RESET} : Make a break every ${_BLUE}X${_RESET} requests \
@@ -95,7 +102,7 @@ for (( i=0;i<$ELEMENTS;i++)); do
 		\n --range : Scan a range of MAC addresses sequentially \
 		\n -np : Parameters by default \
 		\n -h : Print this help menu \
-		\n man mcbash : Look up the manual for more tweaks \
+		\n man mcbash : Look up the manual for more tweaks (proxy support, shell scripts call, etc.)\
 		\n \
 		\n ${_BOLD}Example ${_RESET}: mcbash -u my-dns.com:8080 -w 1.5 -b 10 -d 3 -s 150 -t 2 -k
 		\n Set your default parameters inside this file : \"$HOME/.mcbash/mcbash.conf\"\
@@ -226,21 +233,21 @@ handshaking() {
 	handshake_url=$(echo $dns)'/portal.php?action=handshake&type=stb&token=&mac='$(echo $encoded_mac)
 	cookie="mac=$mac; stb_lang=en; timezone=Europe/Amsterdam; "
 	random_user_agent
-	handshake_token=$(curl --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Cookie: $(echo $cookie)" "$(echo $handshake_url)"); if [ $? -eq 28 ]; then timeout_number=$(( $timeout_number + 1 )) && last_request_timedout=true && echo -ne "\r\033[0KTimeout [$timeout_number]. New attempt in $timebreak_duration seconds." && sleep $timebreak_duration && echo -ne "\r\033[0K\r\033[0KNew attempt..." && return; fi
+	handshake_token=$(curl $proxy_user_option $proxy_url_option --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Cookie: $(echo $cookie)" "$(echo $handshake_url)"); if [ $? -eq 28 ]; then timeout_number=$(( $timeout_number + 1 )) && last_request_timedout=true && echo -ne "\r\033[0KTimeout [$timeout_number]. New attempt in $timebreak_duration seconds." && sleep $timebreak_duration && echo -ne "\r\033[0K\r\033[0KNew attempt..." && return; fi
 	handshake_token=$(echo $handshake_token| grep -o '"token".*' | sed 's/\"token\":// ; s/\}\}//')
 	[[ $handshake_token = "" ]] && echo -ne "\r\033[0K$@${_YELLOW}[$item]${_RESET} ${_RED}$mac ${_RESET}" && return # [empty]
 	[[ $(echo $handshake_token | grep null) ]] && echo -ne "\r\033[0K$@${_YELLOW}[$item]${_RESET} ${_RED}$mac ${_RESET}" && return # [empty]
 	authorization='Bearer '$(echo $handshake_token)
 	profile_url=$(echo $dns)'/portal.php?type=account_info&action=get_main_info&mac='$(echo $mac)
-	profile=$(curl --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $profile_url)")
+	profile=$(curl $proxy_user_option $proxy_url_option --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $profile_url)")
 	[[ $profile == "" ]] && \
 		maybeGEN1portal=true && \
 		profile_url=$(echo $dns)'/portal.php?type=stb&action=get_profile&JsHttpRequest=1-xml='$(echo $mac) && \
-		profile=$(curl --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $profile_url)")
+		profile=$(curl $proxy_user_option $proxy_url_option --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $profile_url)")
 	[[ $profile == "" ]] && unset maybeGEN1portal && echo -ne "\r\033[0K$@${_YELLOW}[$item]${_RESET} ${_RED}$mac ${_RESET}" && return # test
 	[[ -v maybeGEN1portal ]] && \
 		account_url=$(echo $dns)'/portal.php?type=account_info&action=get_main_info&mac='$(echo $mac) && \
-		account=$(curl --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $account_url)") && \
+		account=$(curl $proxy_user_option $proxy_url_option --max-time $timeout -s -X GET -H "Accept: */*" -H "User-Agent: $(echo $user_agent)" -H "Authorization: $(echo $authorization)" -H "Cookie: $(echo $cookie)" "$(echo $account_url)") && \
 		[[ ! $account == "" ]] && \
 		profile=$account
 	expiration_date=$(echo $profile | grep -o "\"phone\":\".*\"" | sed 's/\"phone\":\"//' | sed 's/\".*//')

--- a/mcbash.1
+++ b/mcbash.1
@@ -69,6 +69,18 @@ indicate last MAC address to check.
 .TP
 .B -np
 don't ask for parameters. Set your default parameters in $HOME/.mcbash/mcbash.conf
+.TP
+.B --proxy
+[
+.I http://proxy
+]
+tells mcbash to communicate through http://proxy. See --proxy-user for credentials.
+.TP
+.B --proxy-user
+[
+.I username:password
+]
+set username and password when using --proxy.
 .SH AUTHORS
 Written by dougy147 originally in 2022.
 .SH LICENSE


### PR DESCRIPTION
Adding proxy support for curl requests.
The option `--proxy` needs a proxy URL and supports any authentication method (HTTP, HTTPS,...) thanks to curl option `--proxy-anyauth`.
The option `--proxy-user` is not mandatory but allows you to set your proxy credentials in this format : `user:pass`. 

Example : `mcbash --proxy http://localhost:12345 --proxy-user myname:mypass`